### PR TITLE
Additional SRMD Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,38 @@ with SSP(test_file) as file:
     file.add_resource(test_file)
     file.add_resource(data_file)
 ```
+
+In some cases it may be useful to perform additional parsing on Classifications. For example, to expose
+a known set of keywords as attributes, or to perform additional parsing on entry values (such as parsing
+dates). If an entry has an XML structure describing a more advanced value, this could also be parsed.
+To enable these use cases there is a decorator associate a parser with a given Classification type. If
+a classification of that type is encountered in an SRMD file, it will automatically be parsed with the
+custom parser. An example implementation of a custom parser is shown below:
+```python
+@classification_parser("com.example.custom")
+class CustomClassification(Classification):
+    test1: str
+    test2: str
+
+    def __init__(self, element=None, test1="", test2="", **kwargs):
+        if element is not None:
+            super().__init__(element)
+
+            for entry in self.classification_entries:
+                if entry.keyword == "test1":
+                    self.test1 = entry.text
+                elif entry.keyword == "test2":
+                    self.test2 = entry.text
+        else:
+            super().__init__("com.example.custom", **kwargs)
+            self.test1 = test1
+            self.test2 = test2
+
+    def as_element(self):
+        self.classification_entries = [
+                ClassificationEntry("test1", text=self.test1),
+                ClassificationEntry("test2", text=self.test2)
+        ]
+
+        return super().as_element()
+```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,17 @@ a known set of keywords as attributes, or to perform additional parsing on entry
 dates). If an entry has an XML structure describing a more advanced value, this could also be parsed.
 To enable these use cases there is a decorator associate a parser with a given Classification type. If
 a classification of that type is encountered in an SRMD file, it will automatically be parsed with the
-custom parser. An example implementation of a custom parser is shown below:
+custom parser.
+
+**Simple Example:**
+A simple example of a custom classification is shown below.
+```xml
+<stc:Classification type="com.example.custom">
+    <stc:ClassicationEntry keyword="test1">Value 1</stc:ClassificationEntry>
+    <stc:ClassicationEntry keyword="test2">Value 2</stc:ClassificationEntry>
+</stc:Classification>
+```
+To create a custom parser for the simple schema, we subclass Classification in the following way:
 ```python
 @classification_parser("com.example.custom")
 class CustomClassification(Classification):
@@ -105,6 +115,100 @@ class CustomClassification(Classification):
         self.classification_entries = [
                 ClassificationEntry("test1", text=self.test1),
                 ClassificationEntry("test2", text=self.test2)
+        ]
+
+        return super().as_element()
+```
+
+**Advanced Example:**
+The same functionality can also be used to parse classification schemas with XML structures as values.
+
+```xml
+<stc:Classification type="com.example.custom2">
+    <stc:ClassificationEntry keyword="example">
+        <Family>
+            <Parent name="Alice" occupation="engineer"/>
+            <Parent name="Bob" occupation="programmer"/>
+            <Child name="Eve" age="15"/>
+        </Family>
+    </stc:ClassificationEntry>
+</stc:Classification>
+```
+
+The following is sample code to parse the above schema.
+```python
+@dataclass
+class Parent:
+    name: str
+    occupation: str
+
+    def to_xml(self):
+        element = et.Element("Parent")
+        element.set("name", self.name)
+        element.set("occupation", self.occupation)
+
+        return element
+
+    @classmethod
+    def from_xml(cls, element):
+        return cls(element.get("name"), element.get("occupation"))
+
+
+@dataclass
+class Child:
+    name: str
+    age: int
+
+    def to_xml(self):
+        element = et.Element("Child")
+        element.set("name", self.name)
+        element.set("age", str(self.age))
+
+        return element
+
+    @classmethod
+    def from_xml(cls, element):
+        return cls(element.get("name"), int(element.get("age")))
+
+
+@dataclass
+class Family:
+    parents: list[Parent]
+    children: list[Child]
+
+    def to_xml(self):
+        element = et.Element("Family")
+        element.extend([parent.to_xml() for parent in self.parents])
+        element.extend([child.to_xml() for child in self.children])
+
+        return element
+
+    @classmethod
+    def from_xml(cls, element):
+        parents = [Parent.from_xml(el) for el in element.findall("Parent")]
+        children = [Child.from_xml(el) for el in element.findall("Child")]
+
+        return Family(parents, children)
+
+
+@classification_parser("com.example.custom2")
+class CustomClassification2(Classification):
+    example: Family
+
+    def __init__(self, element=None, example="", **kwargs):
+        if element is not None:
+            super().__init__(element)
+
+            for entry in self.classification_entries:
+                if entry.keyword == "example":
+                    self.example = Family.from_xml(entry.content[0])
+        else:
+            super().__init__("com.example.custom2", **kwargs)
+            self.example = example
+
+    def as_element(self):
+        self.classification_entries = [
+                ClassificationEntry("example", content=[self.example.to_xml()])
         ]
 
         return super().as_element()

--- a/pyssp_standard/__init__.py
+++ b/pyssp_standard/__init__.py
@@ -7,4 +7,4 @@ from pyssp_standard.ssp import SSP
 from pyssp_standard.transformation_types import Transformation
 from pyssp_standard.common_content_ssc import Annotations, Annotation
 
-from pyssp_standard.srmd import SRMD, Classification, ClassificationEntry
+from pyssp_standard.srmd import SRMD, Classification, ClassificationEntry, classification_parser

--- a/pyssp_standard/examplexml
+++ b/pyssp_standard/examplexml
@@ -1,0 +1,4 @@
+<stc:Classification type="com.example.custom">
+    <stc:ClassicationEntry keyword="test1">Värde 1</stc:ClassificationEntry>
+    <stc:ClassicationEntry keyword="test2">Värde 2</stc:ClassificationEntry>
+</stc:Classification>

--- a/pyssp_standard/srmd.py
+++ b/pyssp_standard/srmd.py
@@ -70,7 +70,8 @@ class SRMD(ModelicaXMLFile):
                 self.checksum = hashlib.sha3_256(data.encode()).hexdigest()
 
     def __read__(self):
-        tree = et.parse(self.file_path)
+        tree = et.parse(self.file_path.as_posix())
+        # tree = et.parse(self.file_path)
         self.root = tree.getroot()
         self.version = self.root.get('version')
         self.name = self.root.get('name')
@@ -83,7 +84,17 @@ class SRMD(ModelicaXMLFile):
 
         classifications = self.root.findall('stc:Classification', self.namespaces)
         for classification in classifications:
-            self.add_classification(Classification(element=classification))
+            # self.add_classification(Classification(element=classification))
+            classification_entries = classification.getchildren()
+            type = classification.attrib['type']
+            classification_new = Classification(classification_type=type)
+            for classification_entry in classification_entries:
+                keyword = classification_entry.attrib['keyword']
+                value = classification_entry.text
+                classification_new.add_classification_entry(ClassificationEntry(keyword, value))
+                # self.classifications[-1].add_classification_entry(ClassificationEntry(keyword, value))
+                # self.classifications[-1].add_classification_entry(classification_entry)
+            self.add_classification(classification_new)
 
     def __write__(self):
         attributes = {'version': self.version, 'name': self.name}

--- a/pyssp_standard/srmd.py
+++ b/pyssp_standard/srmd.py
@@ -251,7 +251,6 @@ class SRMD(ModelicaXMLFile):
 
     def __read__(self):
         tree = et.parse(str(self.file_path))
-        # tree = et.parse(self.file_path)
         self.root = tree.getroot()
         self.version = self.root.get('version')
         self.name = self.root.get('name')

--- a/pyssp_standard/srmd.py
+++ b/pyssp_standard/srmd.py
@@ -182,7 +182,12 @@ def classification_parser(type_: str):
     its only argument. The class is expected to have a method as_element(self)
     that returns the XML element representation of the parsed classification.
 
-    One possible implementation would be something like the following:
+    For example: to parse the following classification schema
+    <stc:Classification type="com.example.custom">
+        <stc:ClassicationEntry keyword="test1">Value 1</stc:ClassificationEntry>
+        <stc:ClassicationEntry keyword="test2">Value 2</stc:ClassificationEntry>
+    </stc:Classification>
+    one might do something like the following code snippet.
 
     >>> @classification_parser("com.example.custom")
     >>> class CustomClassification(Classification):

--- a/pyssp_standard/srmd.py
+++ b/pyssp_standard/srmd.py
@@ -2,49 +2,229 @@ import os
 import pathlib
 
 import hashlib
-from pyssp_standard.utils import ModelicaXMLFile, XMLFile
+from pyssp_standard.utils import ModelicaXMLFile, XMLFile, BaseElement
 from pyssp_standard.standard import ModelicaStandard
+from pyssp_standard.common_content_ssc import BaseElement
 from lxml import etree as et
 from lxml.etree import QName
 
 
-class ClassificationEntry(ModelicaStandard):
-    def __init__(self, keyword: str = None, content: str = None, *, element=None):
-        self.keyword = keyword
-        self.content = content
-        if element is not None:
-            self.__read__(element)
+class ClassificationEntry(BaseElement, ModelicaStandard):
+    """SSP Traceability ClassificationEntry
+
+    This class represents a generic ClassificationEntry. As the standard
+    is very flexible in what the "value" of a classification entry can
+    be, the aim is not to fit every usecase, but rather to expose all
+    data required for most common usecases. Therefore, the support for
+    values other than text is only what is necessary to read and write
+    in a standard-compliant manner.
+    """
+    keyword: str
+    type_: str
+    link: str | None
+    linked_type: str | None
+    content: list[et._Element]
+    text: str
+
+    def __init__(self, keyword_or_element: str | et._Element,
+                 type_="text/plain",
+                 link=None,
+                 linked_type=None,
+                 content: list[et._Element] | None = None,
+                 text: str = "",
+                 **kwargs):
+        """ Construct a classification entry.
+
+        This constructor should be called with either an lxml Element
+        or keyword parameters for creating a new Classification Entry.
+        Passing keyword parameters when constructing from an Element
+        will result in values from kw parameters being overriden by the
+        values in the XML element, or set to None if not present in the
+        XML element.
+        """
+        super().__init__(**kwargs)
+
+        self.content = []
+        self.text = ""
+        self.type_ = type_
+        self.link = link
+        self.linked_type = linked_type
+
+        if isinstance(keyword_or_element, et._Element):
+            self.content = []
+            self.__read__(keyword_or_element)
+        elif isinstance(keyword_or_element, str):
+            self.keyword = keyword_or_element
+            if content is not None:
+                self.content = content
+            self.text = text
+        else:
+            raise TypeError(f"Can't init ClassificationEntry with {type(type_or_element)}")
 
     def __read__(self, element):
-        pass
+        self.update({"id": element.get("id"), "description": element.get("description")})
+
+        self.keyword = element.attrib["keyword"]
+        self.type_ = element.get("type", "text/plain")
+        self.link = element.get(QName(self.namespaces["xlink"], "href"))
+        self.linked_type = element.get("linkedType")
+
+        if element.text is not None:
+            self.text = element.text
+
+        for child in element:
+            self.content.append(child)
+
+    def __repr__(self):
+        return f"ClassificationEntry(keyword={self.keyword}, text={self.text!r} content={self.content})"
 
     def as_element(self):
         entry = et.Element(QName(self.namespaces['stc'], 'ClassificationEntry'), attrib={'keyword': self.keyword})
-        entry.text = self.content
+        entry.text = self.text
+        entry.extend(self.content)
+
+        super().update_root(entry)
+
+        if self.type_ != "text/plain":  # Only write if the value differs from the default
+            entry.set("type", self.type_)
+
+        if self.link is not None:  # optional
+            entry.set(QName(self.namespaces["xlink"], "href"), link)
+
+        if self.linked_type is not None:  # optional
+            entry.set("linkedType", linked_type)
+
         return entry
 
 
-class Classification(ModelicaStandard):
+class Classification(BaseElement, ModelicaStandard):
+    """SSP Traceability Classification.
 
-    def __init__(self, classification_type: str = None, *, element=None):
-        self.__classification_entries = []
-        self.__classification_type = classification_type
-        if element is not None:
-            self.__read__(element)
+    This class represents a generic Classification. For easiser parsing
+    of specific Classification types, this class can be subclassed, and
+    registered with the @classification_parser decorator. A possible
+    way to implement this is shown in the documentation for that
+    decorator.
+    """
+    classification_type: str
+    link: str
+    linked_type: str
+    classification_entries: list[ClassificationEntry]
+
+    def __init__(self,
+                 type_or_element: str | et._Element,
+                 link: str | None = None,
+                 linked_type: str | None = None,
+                 entries: list[ClassificationEntry] | None = None,
+                 **kwargs):
+        """ Construct a classification.
+
+        This constructor should be called with either an lxml Element
+        or keyword parameters for creating a new Classification.
+        Passing keyword parameters when constructing from an Element
+        will result in values from kw parameters being overriden by the
+        values in the XML element, or set to None if not present in the
+        XML element.
+        """
+        super().__init__(**kwargs)
+
+        self.link = link
+        self.linked_type = linked_type
+        self.classification_entries = []
+
+        if isinstance(type_or_element, et._Element):
+            self.__read__(type_or_element)
+        elif isinstance(type_or_element, str):
+            self.classification_type = type_or_element
+            self.classification_entries = [] if entries is None else entries
+        else:
+            raise TypeError(f"Can't init Classification with {type(type_or_element)}")
 
     def add_classification_entry(self, classification_entry: ClassificationEntry):
-        self.__classification_entries.append(classification_entry)
+        self.classification_entries.append(classification_entry)
 
     def __read__(self, element):
-        pass
+        # BaseElement doesn't work well with inheritance
+        self.update({"id": element.get("id"), "description": element.get("description")})
+
+        self.classification_type = element.attrib["type"]
+        self.link = element.get(QName(self.namespaces["xlink"], "href"))
+        self.linked_type = element.get("linkedType")
+
+        for entry in element.getchildren():
+            self.add_classification_entry(ClassificationEntry(entry))
 
     def as_element(self):
         classification = et.Element(QName(self.namespaces['stc'], 'Classification'),
-                                    attrib={'type': self.__classification_type})
-        for entry in self.__classification_entries:
+                                    attrib={'type': self.classification_type})
+
+        super().update_root(classification)
+
+        if self.link is not None:
+            classification.set(QName(self.namespaces["xlink"], "href"), self.link)
+
+        if self.linked_type is not None:
+            classification.set("linkedType", self.link)
+
+        for entry in self.classification_entries:
             classification.append(entry.as_element())
 
         return classification
+
+
+classification_parsers: dict[str, Classification] = {}
+
+
+def classification_parser(type_: str):
+    """Decorator for registering a classification parser for a given type.
+
+    The parser class' constructor will be called with the XML element as
+    its only argument. The class is expected to have a method as_element(self)
+    that returns the XML element representation of the parsed classification.
+
+    One possible implementation would be something like the following:
+
+    >>> @classification_parser("com.example.custom")
+    >>> class CustomClassification(Classification):
+    >>>     test1: str
+    >>>     test2: str
+
+    >>>     def __init__(self, element=None, test1="", test2="", **kwargs):
+    >>>         if element is not None:
+    >>>             super().__init__(element)
+
+    >>>             for entry in self.classification_entries:
+    >>>                 if entry.keyword == "test1":
+    >>>                     self.test1 = entry.text
+    >>>                 elif entry.keyword == "test2":
+    >>>                     self.test2 = entry.text
+    >>>         else:
+    >>>             super().__init__("com.example.custom", **kwargs)
+    >>>             self.test1 = test1
+    >>>             self.test2 = test2
+
+    >>>     def as_element(self):
+    >>>         self.classification_entries = [
+    >>>                 ClassificationEntry("test1", text=self.test1),
+    >>>                 ClassificationEntry("test2", text=self.test2)
+    >>>         ]
+
+    >>>         return super().as_element()
+    """
+    def decorator(parser):
+        register_classification_parser(type_, parser)
+
+        return parser
+
+    return decorator
+
+
+def classification_parser_for(type_: str) -> type:
+    return classification_parsers.get(type_, Classification)
+
+
+def register_classification_parser(type_: str, parser: type):
+    classification_parsers[type_] = parser
 
 
 class SRMD(ModelicaXMLFile):
@@ -84,17 +264,9 @@ class SRMD(ModelicaXMLFile):
 
         classifications = self.root.findall('stc:Classification', self.namespaces)
         for classification in classifications:
-            # self.add_classification(Classification(element=classification))
-            classification_entries = classification.getchildren()
-            type = classification.attrib['type']
-            classification_new = Classification(classification_type=type)
-            for classification_entry in classification_entries:
-                keyword = classification_entry.attrib['keyword']
-                value = classification_entry.text
-                classification_new.add_classification_entry(ClassificationEntry(keyword, value))
-                # self.classifications[-1].add_classification_entry(ClassificationEntry(keyword, value))
-                # self.classifications[-1].add_classification_entry(classification_entry)
-            self.add_classification(classification_new)
+            type_ = classification.attrib['type']
+            cls = classification_parser_for(type_)  # select an appropriate parser based on the registry
+            self.add_classification(cls(classification))
 
     def __write__(self):
         attributes = {'version': self.version, 'name': self.name}

--- a/pyssp_standard/srmd.py
+++ b/pyssp_standard/srmd.py
@@ -250,7 +250,7 @@ class SRMD(ModelicaXMLFile):
                 self.checksum = hashlib.sha3_256(data.encode()).hexdigest()
 
     def __read__(self):
-        tree = et.parse(self.file_path.as_posix())
+        tree = et.parse(str(self.file_path))
         # tree = et.parse(self.file_path)
         self.root = tree.getroot()
         self.version = self.root.get('version')

--- a/pyssp_standard/ssb.py
+++ b/pyssp_standard/ssb.py
@@ -43,7 +43,7 @@ class SSB(ModelicaXMLFile):
         super().__init__(*args, identifier='ssb')
 
     def __read__(self):
-        tree = ET.parse(self.file_path, parser=ET.XMLParser(encoding='utf-8'))
+        tree = ET.parse(self.file_path.as_posix(), parser=ET.XMLParser(encoding='utf-8'))
         self.root = tree.getroot()
 
         self.version = self.root.get('version')

--- a/pyssp_standard/ssb.py
+++ b/pyssp_standard/ssb.py
@@ -43,7 +43,7 @@ class SSB(ModelicaXMLFile):
         super().__init__(*args, identifier='ssb')
 
     def __read__(self):
-        tree = ET.parse(self.file_path.as_posix(), parser=ET.XMLParser(encoding='utf-8'))
+        tree = ET.parse(str(self.file_path), parser=ET.XMLParser(encoding='utf-8'))
         self.root = tree.getroot()
 
         self.version = self.root.get('version')

--- a/pyssp_standard/ssd.py
+++ b/pyssp_standard/ssd.py
@@ -178,7 +178,7 @@ class SSD(ModelicaXMLFile):
         super().__init__(file_path=file_path, mode=mode, identifier='ssd')
 
     def __read__(self):
-        tree = ET.parse(str(self.file_path))
+        tree = ET.parse(self.file_path.as_posix())
         self.root = tree.getroot()
 
         system = self.root.findall('ssd:System', self.namespaces)[0]

--- a/pyssp_standard/ssd.py
+++ b/pyssp_standard/ssd.py
@@ -178,7 +178,7 @@ class SSD(ModelicaXMLFile):
         super().__init__(file_path=file_path, mode=mode, identifier='ssd')
 
     def __read__(self):
-        tree = ET.parse(self.file_path.as_posix())
+        tree = ET.parse(str(self.file_path))
         self.root = tree.getroot()
 
         system = self.root.findall('ssd:System', self.namespaces)[0]
@@ -192,7 +192,7 @@ class SSD(ModelicaXMLFile):
         self.version = self.root.get('version')
 
     def __write__(self):
-        tree = ET.parse(self.file_path)
+        tree = ET.parse(str(self.file_path))
         self.root = tree.getroot()
         system = self.root.findall('ssd:System', self.namespaces)
         if system is not None:

--- a/pyssp_standard/ssm.py
+++ b/pyssp_standard/ssm.py
@@ -49,7 +49,7 @@ Parameter Mapping:
 """
 
     def __read__(self):
-        tree = et.parse(self.file_path)
+        tree = et.parse(self.file_path.as_posix())
         self.root = tree.getroot()
         self.top_level_metadata.update(self.root.attrib)
         self.base_element.update(self.root.attrib)

--- a/pyssp_standard/ssm.py
+++ b/pyssp_standard/ssm.py
@@ -49,7 +49,7 @@ Parameter Mapping:
 """
 
     def __read__(self):
-        tree = et.parse(self.file_path.as_posix())
+        tree = et.parse(str(self.file_path))
         self.root = tree.getroot()
         self.top_level_metadata.update(self.root.attrib)
         self.base_element.update(self.root.attrib)

--- a/pyssp_standard/ssv.py
+++ b/pyssp_standard/ssv.py
@@ -19,7 +19,7 @@ class Parameter(TypedDict):
 class SSV(ModelicaXMLFile):
 
     def __read__(self):
-        tree = ET.parse(self.file_path.as_posix())
+        tree = ET.parse(str(self.file_path))
         self.root = tree.getroot()
 
         parameters = self.root.findall('ssv:Parameters', self.namespaces)

--- a/pyssp_standard/ssv.py
+++ b/pyssp_standard/ssv.py
@@ -19,7 +19,7 @@ class Parameter(TypedDict):
 class SSV(ModelicaXMLFile):
 
     def __read__(self):
-        tree = ET.parse(str(self.file_path))
+        tree = ET.parse(self.file_path.as_posix())
         self.root = tree.getroot()
 
         parameters = self.root.findall('ssv:Parameters', self.namespaces)

--- a/pyssp_standard/standard.py
+++ b/pyssp_standard/standard.py
@@ -14,6 +14,8 @@ class ModelicaStandard:
         "srmd": "http://ssp-standard.org/SSPTraceability1/SimulationResourceMetaData",
         # FMI
         "fmi30": "",
+        # XLink
+        "xlink": "http://www.w3.org/1999/xlink"
     }
 
     __resource_path = Path(__file__).parent / "resources"

--- a/pytest/test_srmd.py
+++ b/pytest/test_srmd.py
@@ -1,7 +1,9 @@
-from pyssp_standard.srmd import SRMD, Classification, ClassificationEntry
+from pyssp_standard.srmd import SRMD, Classification, ClassificationEntry, classification_parser
 import pytest
 from pathlib import Path
 import hashlib
+
+from lxml import etree as et
 
 
 @pytest.fixture
@@ -22,10 +24,188 @@ def test_read_srmd():
 def test_create_srmd(write_file):
     print()
     with SRMD(write_file, 'w') as file:
-        classification = Classification(classification_type='test')
+        classification = Classification('test')
         classification.add_classification_entry(ClassificationEntry('test', 'This is a test'))
         file.add_classification(classification)
         file.__check_compliance__()
+
+
+def test_read_write_srmd_simple(write_file):
+    with SRMD(write_file, 'w') as file:
+        classification = Classification("com.example.simple")
+        classification.add_classification_entry(
+                ClassificationEntry("key1", text="value1"))
+
+        file.add_classification(classification)
+
+    with SRMD(write_file) as file:
+        assert len(file.classifications) == 1
+        classification = file.classifications[0]
+        assert classification.classification_type == "com.example.simple"
+        assert len(classification.classification_entries) == 1
+        entry = classification.classification_entries[0]
+
+        assert entry.keyword == "key1"
+        assert entry.text == "value1"
+        assert len(entry.content) == 0
+
+
+def test_read_write_srmd_multiple(write_file):
+    data = {
+           "com.example.mult1": {"key1": "value1", "key2": "value2"},
+           "com.example.mult2": {"key3": "value3"}
+            }
+
+    with SRMD(write_file, 'w') as file:
+        for classification_type, entries in data.items():
+            classification = Classification(classification_type)
+            for key, value in entries.items():
+                classification.add_classification_entry(ClassificationEntry(key, text=value))
+
+            file.add_classification(classification)
+
+    actual = {}
+    with SRMD(write_file) as file:
+        for classification in file.classifications:
+            entries = {}
+            for entry in classification.classification_entries:
+                entries[entry.keyword] = entry.text
+
+            actual[classification.classification_type] = entries
+
+    assert actual == data
+
+
+def test_read_write_srmd_duplicate(write_file):
+    data = {
+           "com.example.duplicate": [("key1", "value1"), ("key2", "value2")],
+            }
+
+    with SRMD(write_file, 'w') as file:
+        for classification_type, entries in data.items():
+            classification = Classification(classification_type)
+            for key, value in entries:
+                classification.add_classification_entry(ClassificationEntry(key, text=value))
+
+            file.add_classification(classification)
+
+    actual = {}
+    with SRMD(write_file) as file:
+        for classification in file.classifications:
+            entries = []
+            for entry in classification.classification_entries:
+                entries.append((entry.keyword, entry.text))
+
+            actual[classification.classification_type] = entries
+
+    assert actual == data
+
+
+def test_read_write_srmd_xml(write_file):
+    with SRMD(write_file, 'w') as file:
+        classification = Classification(
+                "com.example.xml",
+                link="test.txt",
+                linked_type="text/plain"
+        )
+        elem = et.Element("a")
+        elem.append(et.Element("b", example="attribute"))
+
+        classification.add_classification_entry(
+                ClassificationEntry("key1", type_="application/xml", content=[elem]))
+
+        file.add_classification(classification)
+
+    with SRMD(write_file) as file:
+        assert len(file.classifications) == 1
+        classification = file.classifications[0]
+        assert classification.classification_type == "com.example.xml"
+        assert len(classification.classification_entries) == 1
+        entry = classification.classification_entries[0]
+
+        assert entry.keyword == "key1"
+        assert entry.text == ""
+        assert entry.type_ == "application/xml"
+        assert len(entry.content) == 1
+
+        elem = entry.content[0]
+        assert elem.tag == "a"
+        assert len(elem) == 1
+
+        child = elem[0]
+        assert child.tag == "b"
+        assert child.get("example") == "attribute"
+
+
+def test_read_write_srmd_attrs(write_file):
+    with SRMD(write_file, 'w') as file:
+        classification = Classification(
+                "com.example.attrs",
+                description="Test"
+        )
+
+        classification.add_classification_entry(
+                ClassificationEntry("key1", description="Test2", text="Testing"))
+
+        file.add_classification(classification)
+
+    with SRMD(write_file) as file:
+        assert len(file.classifications) == 1
+        classification = file.classifications[0]
+        assert classification.classification_type == "com.example.attrs"
+        assert len(classification.classification_entries) == 1
+        assert classification.description == "Test"
+        entry = classification.classification_entries[0]
+
+        assert entry.keyword == "key1"
+        assert entry.text == "Testing"
+        assert entry.description == "Test2"
+
+
+@classification_parser("com.example.custom")
+class CustomClassification(Classification):
+    test1: str
+    test2: str
+
+    def __init__(self, element=None, test1="", test2="", **kwargs):
+        if element is not None:
+            super().__init__(element)
+
+            for entry in self.classification_entries:
+                if entry.keyword == "test1":
+                    self.test1 = entry.text
+                elif entry.keyword == "test2":
+                    self.test2 = entry.text
+        else:
+            super().__init__("com.example.custom", **kwargs)
+            self.test1 = test1
+            self.test2 = test2
+
+    def as_element(self):
+        self.classification_entries = [
+                ClassificationEntry("test1", text=self.test1),
+                ClassificationEntry("test2", text=self.test2)
+        ]
+
+        return super().as_element()
+
+
+def test_read_write_srmd_custom_parser(write_file):
+    with SRMD(write_file, 'w') as file:
+        classification = CustomClassification(
+            test1="testing1",
+            test2="testing2"
+        )
+        file.add_classification(classification)
+
+    with SRMD(write_file) as file:
+        assert len(file.classifications) == 1
+        classification = file.classifications[0]
+        assert classification.classification_type == "com.example.custom"
+        assert isinstance(classification, CustomClassification)
+
+        assert classification.test1 == "testing1"
+        assert classification.test2 == "testing2"
 
 
 def test_data_assign(write_file):

--- a/pytest/test_srmd.py
+++ b/pytest/test_srmd.py
@@ -1,4 +1,4 @@
-from pyssp_standard.srmd import SRMD, Classification, ClassificationEntry, classification_parser
+from pyssp_standard import SRMD, Classification, ClassificationEntry, classification_parser
 import pytest
 from pathlib import Path
 import hashlib


### PR DESCRIPTION
The support for SRMD is basically complete, except for lack of support
for Annotations. This is a wider problem, since most SSP elements can
contain Annotations.

There is (experimental) support for custom classification parsers. This
is intended to support usecases like MIC Core, where there is a defined
set of keywords, with values that may require additional parsing, such
as dates to be useful.

Currently, SRMD `__init__` methods are implemented in a slightly weird
way, where they either take an XML element or a str as their first
argument. This is for consistency with other classes in the project.