### PR TITLE
Support for creating new SSP archives

### DIFF
--- a/pyssp_standard/fmu.py
+++ b/pyssp_standard/fmu.py
@@ -129,8 +129,8 @@ class FMU(ZIPFile):
 
         return self
 
-    def __init__(self, source_path, target_path=None, readonly=False):
-        super().__init__(source_path, target_path, readonly)
+    def __init__(self, source_path, target_path=None, mode="a", readonly=None):
+        super().__init__(source_path, target_path, mode=mode, readonly=readonly)
         self.fmu_binaries_path :Path = None
         self.fmu_documentation_path :Path = None
 

--- a/pyssp_standard/fmu.py
+++ b/pyssp_standard/fmu.py
@@ -146,9 +146,9 @@ FMU:
 
     @property
     def model_description(self):
-        md = list(self.unpacked_path.glob('modelDescription.xml'))[0]
+        md = self.unpacked_path / "modelDescription.xml"
         return ModelDescription(md)
-    
+
     @property
     def binaries(self):
         """ 

--- a/pyssp_standard/ssd.py
+++ b/pyssp_standard/ssd.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+from typing import Self
+
 from pyssp_standard.common_content_ssc import Enumerations, Annotations, Annotation
 from pyssp_standard.unit import Units
 from pyssp_standard.utils import ModelicaXMLFile
@@ -39,40 +42,53 @@ class Connection(ModelicaStandard):
             return False
 
     def as_element(self) -> ET.Element:
-        self.__root = ET.Element(QName(self.namespaces['ssd'], 'Connection'),
-                                 attrib={'startElement': self.start_element,
-                                         'startConnector': self.start_connector,
-                                         'endElement': self.end_element,
-                                         'endConnector': self.end_connector})
+        attrib = {
+                'startElement': self.start_element,
+                'startConnector': self.start_connector,
+                'endElement': self.end_element,
+                'endConnector': self.end_connector
+        }
+        attrib = {k: v for k, v in attrib.items() if v is not None}
+
+        self.__root = ET.Element(QName(self.namespaces['ssd'], 'Connection'), **attrib)
         return self.__root
 
     def as_dict(self):
         return {'source': self.start_element, 'signal': self.start_connector,
                 'target': self.end_element, 'receiver': self.end_connector}
 
-    def __rep__(self) -> str:
-        return f"""source {self.start_element} - {self.start_connector} -> target {self.end_element} - {self.end_connector}""" 
+    def __repr__(self) -> str:
+        return f"""source {self.start_element} - {self.start_connector} -> target {self.end_element} - {self.end_connector}"""
 
 
 class Connector(ModelicaStandard):
 
-    def __init__(self, element):
-        self.name = ""
-        self.kind = ""
-        self.value_type = ""
+    def __init__(self, element=None, name="", kind=""):
+        self.name = name
+        self.kind = kind
 
-        self.__read__(element)
+        if element is not None:
+            self.__read__(element)
 
     def __read__(self, element: ET.Element):
         self.name = element.get('name')
         self.kind = element.get('kind')
 
+    def as_element(self):
+        elem = ET.Element(
+                QName(self.namespaces["ssd"], "Connector"),
+                name=self.name,
+                kind=self.kind
+        )
+
+        return elem
+
     def as_dict(self):
         return {'name': self.name, 'kind': self.kind}
 
-class Component(ModelicaStandard):
 
-    def __init__(self, element):
+class Component(ModelicaStandard):
+    def __init__(self, element=None):
         self.component_type = None
         self.name = None
         self.source = None
@@ -81,13 +97,40 @@ class Component(ModelicaStandard):
         self.parameter_bindings = None
         self.annotations = None
 
-        self.__read__(element)
+        if element is not None:
+            self.__read__(element)
 
     def __read__(self, element):
         self.name = element.get('name')
-        connectors = element.findall('ssd:Connectors', namespaces=self.namespaces)
-        for connector in connectors[0].findall('ssd:Connector', namespaces=self.namespaces):
-            self.connectors.append(Connector(connector))
+        self.component_type = element.get('type')
+        self.source = element.get('source')
+        self.implementation = element.get('implementation')
+
+        connectors = element.find('ssd:Connectors', namespaces=self.namespaces)
+        if connectors is not None:
+            for connector in connectors.findall('ssd:Connector', namespaces=self.namespaces):
+                self.connectors.append(Connector(connector))
+
+    def as_element(self):
+        element = ET.Element(QName(self.namespaces["ssd"], "Component"), name=self.name)
+
+        if self.component_type is not None:
+            element.set("type", self.component_type)
+
+        if self.source is not None:
+            element.set("source", self.source)
+
+        if self.implementation is not None:
+            element.set("implementation", self.implementation)
+
+        if self.connectors:
+            connectors = ET.Element(QName(self.namespaces["ssd"], "Connectors"))
+            for connector in self.connectors:
+                connectors.append(connector.as_element())
+
+            element.append(connectors)
+
+        return element
 
     def as_dict(self):
         return {'name': self.name, 'connectors': [connector.as_dict() for connector in self.connectors]}
@@ -109,52 +152,112 @@ class Element(ModelicaStandard):
 
 
 class System(ModelicaStandard):
+    name: str
+    elements: list[Component | Self]
+    connections: list[Connection]
 
-    def __init__(self, system_element: ET.Element):
-        self.name = None
-        self.element = None
-        self.__connections : list[Connection] = []
+    connectors: list[Connector]
+    parameter_bindings: list
+    signal_dictionaries: list
+    annotations: Annotation | None
 
-        self.connectors : list[Connector] = []
+    def __init__(
+            self,
+            system_element: ET.Element = None,
+            name: str = "",
+        ):
+        self.name = name
+        self.elements = []
+        self.connections: list[Connection] = []
+
+        self.connectors: list[Connector] = []
         self.parameter_bindings = []
         self.signal_dictionaries = []
+        self.annotations = None
 
-        self.__read__(system_element)
+        if system_element is not None:
+            self.__read__(system_element)
+
+    def parse_element(self, elem):
+        if elem.tag == QName(self.namespaces["ssd"], "Component"):
+            return Component(elem)
+        elif elem.tag == QName(self.namespaces["ssd"], "System"):
+            return System(elem)
+        else:
+            # Unfortunately, no support for SignalDictionaries yet :(
+            return elem
 
     def __read__(self, element):
         self.name = element.get('name', None)
-        elements = element.findall('ssd:Elements', namespaces=self.namespaces)
-        if len(elements) > 0:
-            self.element = Element(elements[0])
+
+        connectors = element.find('ssd:Connectors', namespaces=self.namespaces)
+        if connectors is not None:
+            for connector in connectors.findall('ssd:Connector', namespaces=self.namespaces):
+                self.connectors.append(Connector(connector))
+
+        elements = element.find('ssd:Elements', namespaces=self.namespaces)
+        if elements is not None:
+            self.elements = [self.parse_element(child) for child in elements]
 
         connections = element.findall('ssd:Connections', namespaces=self.namespaces)
         if len(connections) > 0:
             for connection in connections[0].findall('ssd:Connection', namespaces=self.namespaces):
-                self.__connections.append(Connection(connection))
+                self.connections.append(Connection(connection))
 
-    @property
-    def connections(self):
-        return self.__connections
+    def as_element(self):
+        element = ET.Element(QName(self.namespaces["ssd"], "System"), name=self.name)
+
+        if self.connectors:
+            connectors = ET.Element(QName(self.namespaces["ssd"], "Connectors"))
+            connectors.extend(connector.as_element() for connector in self.connectors)
+            element.append(connectors)
+
+        if self.elements:
+            elements = ET.Element(QName(self.namespaces["ssd"], "Elements"))
+            elements.extend(el.as_element()
+                  if isinstance(el, (Component, System))
+                  else el for el in self.elements)
+            element.append(elements)
+
+        if self.connections:
+            connections = ET.Element(QName(self.namespaces["ssd"], "Connections"))
+            connections.extend(connection.as_element() for connection in self.connections)
+            element.append(connections)
+
+        return element
 
 
 class DefaultExperiment(ModelicaStandard):
 
     def __init__(self, element: ET.Element = None):
-        self.start_time = None
-        self.end_time = None
-        self.annotations: Annotations = Annotations()
+        self.start_tim: float = None
+        self.stop_time: float = None
+        self.annotations: Annotations = Annotations(namespace="ssd")
 
         if element is not None:
             self.__read__(element)
 
     def __read__(self, element):
-        self.start_time = element.get('startTime')
-        self.end_time = element.get('endTime')
+        self.start_time = float(element.get('startTime'))
+        self.stop_time = float(element.get('stopTime'))
 
-        annotations = element.findall('ssd:Annotations', self.namespaces)
-        if len(annotations) > 0:
-            for annotation in annotations[0].findall('ssc:Annotation', self.namespaces):
+        annotations = element.find('ssd:Annotations', self.namespaces)
+
+        if annotations is not None:
+            for annotation in annotations.findall('ssc:Annotation', self.namespaces):
                 self.annotations.add_annotation(Annotation(annotation))
+
+    def as_element(self):
+        elem = ET.Element(
+                QName(self.namespaces["ssd"], "DefaultExperiment"),
+                startTime=str(self.start_time),
+                stopTime=str(self.stop_time)
+        )
+
+        if not self.annotations.is_empty():
+            elem.append(self.annotations.element())
+
+        return elem
 
 
 class SSD(ModelicaXMLFile):
@@ -166,14 +269,11 @@ class SSD(ModelicaXMLFile):
 
         self.system = None
         self.default_experiment = None
-        self.__enumerations: Enumerations = Enumerations()
+        self.__enumerations: Enumerations = Enumerations(namespace="ssd")
         self.__units: Units = Units()
 
         self.connections_to_add = []
         self.connections_to_remove = []
-
-        if mode not in ['r', 'a']:
-            raise Exception('Only read mode and append mode are supported for SSD files')
 
         super().__init__(file_path=file_path, mode=mode, identifier='ssd')
 
@@ -181,29 +281,60 @@ class SSD(ModelicaXMLFile):
         tree = ET.parse(str(self.file_path))
         self.root = tree.getroot()
 
-        system = self.root.findall('ssd:System', self.namespaces)[0]
-        self.system = System(system)
+        self.top_level_metadata.update(self.root.attrib)
+        self.base_element.update(self.root.attrib)
+
+        system = self.root.find('ssd:System', self.namespaces)
+        if system is not None:
+            self.system = System(system)
 
         default_experiment = self.root.findall('ssd:DefaultExperiment', self.namespaces)
         if len(default_experiment) > 0:
             self.default_experiment = DefaultExperiment(default_experiment[0])
 
+        # Unclear if the namespace should be ssc or ssd
+        enumerations = self.root.find("ssd:Enumerations", self.namespaces)
+        if enumerations is None:
+            # If this find succeeds the document is actually invalid
+            enumerations = self.root.find("ssc:Enumerations", self.namespaces)
+
+        if enumerations is not None:
+            self.__enumerations = Enumerations(enumerations, namespace="ssd")
+
         self.name = self.root.get('name')
         self.version = self.root.get('version')
 
     def __write__(self):
-        tree = ET.parse(str(self.file_path))
-        self.root = tree.getroot()
-        system = self.root.findall('ssd:System', self.namespaces)
-        if system is not None:
-            connections_set = system[0].findall('ssd:Connections', self.namespaces)[0]
-            for target in self.connections_to_remove:
-                matching_elements = connections_set.findall('ssd:Connection', namespaces=self.namespaces)
-                for element in matching_elements:
-                    if Connection(element) == target:
-                        element.getparent().remove(element)
-            for add_connection in self.connections_to_add:
-                connections_set.append(add_connection.as_element())
+        # tree = ET.parse(str(self.file_path))
+        # self.root = tree.getroot()
+        self.root = ET.Element(
+                QName(self.namespaces["ssd"], "SystemStructureDescription"),
+                version=self.version,
+                name=self.name
+        )
+
+        self.root = self.top_level_metadata.update_root(self.root)
+        self.root = self.base_element.update_root(self.root)
+
+        if self.system is not None:
+            self.root.append(self.system.as_element())
+
+        if self.default_experiment is not None:
+            self.root.append(self.default_experiment.as_element())
+
+        if self.__enumerations is not None and self.__enumerations.enumerations:
+            self.root.append(self.__enumerations.as_element())
+
+        # system = self.root.findall('ssd:System', self.namespaces)
+        # if system is not None:
+        #     connections_set = system[0].findall('ssd:Connections', self.namespaces)[0]
+        #     for target in self.connections_to_remove:
+        #         matching_elements = connections_set.findall('ssd:Connection', namespaces=self.namespaces)
+        #         for element in matching_elements:
+        #             if Connection(element) == target:
+        #                 element.getparent().remove(element)
+        #     for add_connection in self.connections_to_add:
+        #         connections_set.append(add_connection.as_element())
 
     def add_connection(self, connection: Connection):
         if type(connection) is not Connection:
@@ -247,21 +378,22 @@ class SSD(ModelicaXMLFile):
             :param parent: the name of the parent component, utilizes 'in' for lookup
         """
 
-        matching_connectors = {}
-        component_connectors = self.system.element.as_dict()
+        matching_connectors = defaultdict(list)
 
-        for component in component_connectors:
-            if parent is not None and parent not in component['name']:
+        for element in self.system.elements:
+            if not isinstance(element, (System, Component)):
                 continue
 
-            for connector in component['connectors']:
-                if kind is not None and kind != connector['kind']:
+            if parent is not None and parent not in element.name:
+                continue
+
+            for connector in element.connectors:
+                if kind is not None and kind != connector.kind:
                     continue
-                if name is not None and name not in connector['name']:
+                if name is not None and name not in connector.name:
                     continue
 
-                if component['name'] not in matching_connectors.keys():
-                    matching_connectors[component['name']] = []
-                matching_connectors[component['name']].append({'name': connector['name'], 'kind': connector['kind']})
+                matching_connectors[element.name].append(
+                        {"name": connector.name, "kind": connector.kind})
 
         return matching_connectors

--- a/pyssp_standard/ssd.py
+++ b/pyssp_standard/ssd.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import Self
 
 from pyssp_standard.common_content_ssc import Enumerations, Annotations, Annotation
 from pyssp_standard.unit import Units
@@ -153,7 +152,7 @@ class Element(ModelicaStandard):
 
 class System(ModelicaStandard):
     name: str
-    elements: list[Component | Self]
+    elements: "list[Component | System]"  # ugly, because of forward declarations. Fixed in py3.14+
     connections: list[Connection]
 
     connectors: list[Connector]

--- a/pyssp_standard/ssp.py
+++ b/pyssp_standard/ssp.py
@@ -3,8 +3,7 @@ import tempfile
 import zipfile
 import shutil
 from pathlib import Path, PosixPath
-from warnings import deprecated
-
+import warnings
 from pyssp_standard.ssd import SSD
 from pyssp_standard.ssb import SSB
 from pyssp_standard.ssv import SSV
@@ -41,27 +40,25 @@ class VariantsProxy:
 
 
 class SSP(ZIPFile):
-
     def __enter__(self):
         super().__enter__()
-        self.ssp_resource_path = self.unpacked_path / 'resources'
+        self.ssp_resource_path = self.unpacked_path / "resources"
 
         return self
 
     def __init__(self, source_path, target_path=None, mode="a", readonly=None):
         super().__init__(source_path, target_path, mode=mode, readonly=readonly)
-        self.ssp_resource_path :Path = None
+        self.ssp_resource_path: Path = None
 
     def __rep__(self) -> str:
         spacing = "\t\t"
-        return \
-f"""{'_'*100}
+        return f"""{"_" * 100}
 SSP:
     Path       {self.file_path}
     Temp_dir:  {self.unpacked_path}
     Resources:
 {spacing}{spacing.join([str(r) for r in self.resources])}
-{'_'*100}
+{"_" * 100}
 """
 
     @property
@@ -74,37 +71,43 @@ SSP:
 
     @property
     def ssd(self):
-        ssd = list(self.unpacked_path.glob('*.ssd'))[0]
+        message = (
+            "The ssd property is deprecated. Use SSP.system_structure to access the default "
+            "variant, and SSP.variants to access other variant SSDs."
+        )
+        warnings.warn(message, DeprecationWarning)
+
+        ssd = list(self.unpacked_path.glob("*.ssd"))[0]
         return SSD(ssd)
 
     @property
     def ssv(self):
-        ssv = list(self.ssp_resource_path.glob('*.ssv'))
+        ssv = list(self.ssp_resource_path.glob("*.ssv"))
         return [SSV(ssv) for ssv in ssv]
 
     @property
     def ssm(self):
-        ssm = list(self.ssp_resource_path.glob('*.ssm'))
+        ssm = list(self.ssp_resource_path.glob("*.ssm"))
         return [SSM(file) for file in ssm]
 
     @property
     def ssb(self):
-        ssb = list(self.ssp_resource_path.glob('*.ssb'))
+        ssb = list(self.ssp_resource_path.glob("*.ssb"))
         return [SSB(file) for file in ssb]
 
     @property
     def fmu(self):
-        fmu = list(self.ssp_resource_path.glob('*.fmu'))
+        fmu = list(self.ssp_resource_path.glob("*.fmu"))
         return [FMU(file) for file in fmu]
 
     @property
     def resources(self):
-        """ 
+        """
         Returns a list of available resources in the ssp folder /resources
         """
         return [f for f in self.get_files(self.ssp_resource_path).keys()]
 
-    def add_resource(self, file :Path):
+    def add_resource(self, file: Path):
         """
         Add something to the resource folder of the ssp.
         :param resource: filepath of the object to add.
@@ -119,4 +122,3 @@ SSP:
             resource_name = resource_name.name
 
         self.remove_file(f"resources/{resource_name}")
-        

--- a/pyssp_standard/utils.py
+++ b/pyssp_standard/utils.py
@@ -148,6 +148,8 @@ class ZIPFile:
         if self.mode == "r" or (self.mode == "a" and Path(self.file_path).exists()):
             with zipfile.ZipFile(self.file_path, "r") as zip_ref:
                 zip_ref.extractall(self.__unpacked_path)
+        else:
+            self.__unpacked_path.mkdir()
 
         self.__in_context = True
         return self

--- a/pyssp_standard/utils.py
+++ b/pyssp_standard/utils.py
@@ -263,7 +263,6 @@ class ZIPFile:
         archive_dir = self.get_file_temp_path(rel_path)
         archive_dir.mkdir(parents=True, exist_ok=True)  # eqv. to mkdir -p ...
 
-        rel_path = os.path.join(rel_path, os.path.basename(file))
         rel_path = Path(rel_path) / Path(file).name
 
         temp_path = self.get_file_temp_path(rel_path)

--- a/pyssp_standard/utils.py
+++ b/pyssp_standard/utils.py
@@ -1,4 +1,3 @@
-
 import shutil
 import tempfile
 from pathlib import Path, PosixPath
@@ -6,6 +5,7 @@ from abc import ABC, abstractmethod
 import zipfile
 import xmlschema
 import os
+import warnings
 from lxml import etree as ET
 
 from pyssp_standard.common_content_ssc import Annotations, Annotation, BaseElement, TopLevelMetaData
@@ -44,25 +44,27 @@ class XMLFile(ABC):
     def TopLevelMetaData(self):
         return self.top_level_metadata
 
-    def __init__(self, file_path, mode='r'):
+    def __init__(self, file_path, mode="r"):
         """
         :param mode: [r]ead, [a]ppend or [w]rite
         """
         self.__mode = mode
         if type(file_path) is not PosixPath:
             file_path = Path(file_path)
-    
+
         self.__file_path = file_path
         self.root = None
         self.base_element: BaseElement = BaseElement()
         self.top_level_metadata: TopLevelMetaData = TopLevelMetaData()
 
-        if mode == 'r' or mode == 'a':
+        if mode == "r" or mode == "a":
             self.__read__()
 
     def write_to_file(self, filepath):
-        xml_string = ET.tostring(self.root, pretty_print=True, encoding='utf-8', xml_declaration=True)
-        with open(filepath, 'wb') as file:
+        xml_string = ET.tostring(
+            self.root, pretty_print=True, encoding="utf-8", xml_declaration=True
+        )
+        with open(filepath, "wb") as file:
             file.write(xml_string)
 
     def check_compliance(self, schema, namespaces):
@@ -72,9 +74,9 @@ class XMLFile(ABC):
         else:
             schema = xmlschema.XMLSchema10(schema)
 
-        if self.__mode in ['a', 'w']:  # Temporary file creation
+        if self.__mode in ["a", "w"]:  # Temporary file creation
             with tempfile.TemporaryDirectory(suffix="_pyssp") as temp_dir:
-                temp_file_path = Path(temp_dir) / 'tmp.xml'
+                temp_file_path = Path(temp_dir) / "tmp.xml"
                 self.__write__()
                 self.write_to_file(temp_file_path)
 
@@ -93,7 +95,7 @@ class XMLFile(ABC):
         self.write_to_file(self.__file_path)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.__mode in ['w', 'a']:
+        if self.__mode in ["w", "a"]:
             self.__write__()
             self.__save__()
 
@@ -127,8 +129,7 @@ class ModelicaXMLFile(XMLFile, ModelicaStandard):
         register_namespaces()
         return self
 
-    def __init__(self, file_path, mode='r', identifier='unknown'):
-
+    def __init__(self, file_path, mode="r", identifier="unknown"):
         self.__identifier = identifier
         self.__annotations = Annotations()
         super().__init__(file_path, mode)
@@ -137,40 +138,65 @@ class ModelicaXMLFile(XMLFile, ModelicaStandard):
 class ZIPFile:
     """
     All operations need to be in context and will be applied against temp dir
-    
+
     """
 
     def __enter__(self):
         self.__temp_path = Path(tempfile.mkdtemp(prefix="pyssp_"))
         self.__unpacked_path = self.__temp_path / self.file_path.stem
 
-        with zipfile.ZipFile(self.file_path, 'r') as zip_ref:
-            zip_ref.extractall(self.__unpacked_path)
+        if self.mode == "r" or (self.mode == "a" and Path(self.file_path).exists()):
+            with zipfile.ZipFile(self.file_path, "r") as zip_ref:
+                zip_ref.extractall(self.__unpacked_path)
 
         self.__in_context = True
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if not self.readonly and self.__changed:
-
-            zip_file_path = shutil.make_archive(self.__unpacked_path, 'zip', self.__unpacked_path)
+        if not self.mode == "r" and self.__changed:
+            zip_file_path = shutil.make_archive(self.__unpacked_path, "zip", self.__unpacked_path)
             shutil.copy(zip_file_path, self.save_path)
 
         shutil.rmtree(self.__temp_path)
-        
+
         self.__in_context = False
 
-    def __init__(self, source_path : Path, target_path: Path=None, readonly=False):
+    def __init__(self, source_path: Path, target_path: Path = None, mode="a", readonly=None):
         """
-        if target_path is not specified it will overwrite the opened file at exit
-        this can be probibited by specifying readonly
+        If target_path is not specified it will overwrite the opened file at exit.
+        This can be probibited by specifying mode="r".
+
+        Opening modes:
+            * [a]ppend: open and read the contents of an SSP archive,
+              creating an empty archive if the file doesn't exist
+            * [w]rite: create an empty SSP archive to write to, overriding the target_path
+            * [r]ead: read the contents of an SSP archive without modifying
+              the contents.
+
+        The readonly parameter is deprecated (but remains for backwards-compatibility).
+        Migrating can be done by changing readonly=True to mode='r' and readonly=False
+        to mode='a'.
         """
         if type(source_path) is not PosixPath:
             source_path = Path(source_path)
-    
+
         self.file_path = source_path
-        self.save_path = target_path if target_path != None else source_path
-        self.readonly = readonly
+        self.save_path = target_path if target_path is not None else source_path
+
+        # Remove once the readonly parameter is removed!
+        if readonly is not None:
+            if mode != "a":
+                raise ValueError("The mode parameter makes readonly redundant. Specify only mode!")
+
+            mode = "r" if readonly else "a"
+            type_name = type(self).__name__
+            message = (
+                f"The readonly parameter is deprecated. Use {type_name}(..., {mode=})"
+                f"instead of {type_name}(..., {readonly=}) to maintain current behavior"
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=3)
+
+        self.mode = mode
 
         self.__changed = False
         self.__in_context = False
@@ -182,8 +208,8 @@ class ZIPFile:
             raise Exception("Function or variable not accessable unless opened using 'with'")
 
     @staticmethod
-    def get_files(dir : Path):
-        return {os.path.relpath(p, dir):p for p in dir.rglob('*')}
+    def get_files(dir: Path):
+        return {os.path.relpath(p, dir): p for p in dir.rglob("*")}
 
     @property
     def unpacked_path(self):
@@ -204,7 +230,7 @@ class ZIPFile:
         """
         self.check_context()
         return self.__files.keys()
-    
+
     @property
     def files_abs(self):
         """
@@ -216,26 +242,36 @@ class ZIPFile:
     def get_file_temp_path(self, rel_path):
         """
         translate from rel_path to abs_path
-        
+
         """
         self.check_context()
-        return self.__files[rel_path]
-        
-    def add_file(self, file : Path, rel_path = ""):
+        return self.__unpacked_path / rel_path
+
+    def add_file(self, file: Path, rel_path="", overwrite=False):
         """
         Add something to the resource folder of the ssp.
         :param file: filepath of the object to add.
-        :param rel_path: relative path inside archive, omitt '/' in the beginning 
+        :param rel_path: relative path inside archive, omitt '/' in the beginning
+        :param overwrite: if True, overwrite file in archive if it already exists
         """
         self.check_context()
-        if self.readonly:
+        if self.mode == "r":
             raise Exception("Changes are not allowed in readonly archive")
 
         self.__changed = True
+        # Create subdirectory if it doesn't already exist
+        archive_dir = self.get_file_temp_path(rel_path)
+        archive_dir.mkdir(parents=True, exist_ok=True)  # eqv. to mkdir -p ...
+
         rel_path = os.path.join(rel_path, os.path.basename(file))
-    
-        if rel_path not in self.files_rel:
-            shutil.copy(file, self.__unpacked_path / rel_path)
+        rel_path = Path(rel_path) / Path(file).name
+
+        temp_path = self.get_file_temp_path(rel_path)
+        if overwrite or not temp_path.exists():
+            shutil.copy(file, temp_path)
+        else:
+            # This shouldn't fail silently
+            raise FileExistsError(f"File {rel_path} already exists in archive")
 
     def remove_file(self, rel_path):
         """
@@ -243,20 +279,19 @@ class ZIPFile:
         e.g. SystemStructure.ssd
         """
         self.check_context()
-        if self.readonly:
+        if self.mode == "r":
             raise Exception("Changes are not allowed in readonly archive")
 
         self.__changed = True
-        file : Path = self.__unpacked_path / rel_path
+        file: Path = self.__unpacked_path / rel_path
 
         if file.exists():
             file.unlink()
         else:
             raise FileNotFoundError(f"Not found {file}")
-        
+
 
 class SSPElement(ABC):
-
     @abstractmethod
     def to_element(self) -> ET.Element:
         pass
@@ -267,9 +302,8 @@ class SSPElement(ABC):
 
 
 class EmptyElement(ET.ElementBase):
-
     def __init__(self, tag, attrib=None, **kwargs):
         super().__init__(tag, attrib, **kwargs)
 
     def __repr__(self):
-        return ET.tostring(self, encoding='utf-8')
+        return ET.tostring(self, encoding="utf-8")

--- a/pytest/test_common.py
+++ b/pytest/test_common.py
@@ -1,6 +1,5 @@
-
 import pytest
-from pyssp_standard.common_content_ssc import Annotations, Annotation
+from pyssp_standard.common_content_ssc import Annotations, Annotation, Enumerations, Enumeration, BaseElement, Item
 
 
 def test_annotation_creation():
@@ -9,3 +8,21 @@ def test_annotation_creation():
     annotations = Annotations()
     annotations.add_annotation(annotation)
     assert annotations.is_empty() is False
+
+
+def test_enumerations():
+    items = [Item("test_a", 1), Item("test_b", 2)]
+
+    enum = Enumeration(name="test_enum", items=items)
+    enums = Enumerations([enum])
+
+    elem = enums.as_element()
+
+    enums2 = Enumerations(elem)
+    enum2 = enums2.enumerations[0]
+    print(enums2.enumerations)
+    print(enum2.items, items)
+    assert enum2.items == items
+    assert enum2.name == "test_enum"
+
+

--- a/pytest/test_ssd.py
+++ b/pytest/test_ssd.py
@@ -1,6 +1,7 @@
+import tempfile
 import pytest
 from pathlib import Path
-from pyssp_standard.ssd import SSD, Connection
+from pyssp_standard.ssd import SSD, Connection, System, DefaultExperiment, Component, Connector
 import shutil
 
 
@@ -16,6 +17,13 @@ def modify_file():
     shutil.copy(source_path, test_file)
     yield test_file
     test_file.unlink()
+
+
+@pytest.fixture
+def write_file():
+    with tempfile.NamedTemporaryFile(delete_on_close=False) as f:
+        f.close()
+        yield f.name
 
 
 def test_compliance_check(read_file):
@@ -38,3 +46,61 @@ def test_modify(modify_file):
         file.remove_connection(Connection(start_element="Atmos", start_connector="Tamb",
                                           end_element="Consumer", end_connector="Tamb"))
         file.__check_compliance__()
+
+
+def test_create_ssd(write_file):
+    with SSD(write_file, mode="w") as ssd:
+        ssd.name = "Test SSD"
+        ssd.version = "1.0"
+
+        ssd.default_experiment = DefaultExperiment()
+        ssd.default_experiment.start_time = 0.0
+        ssd.default_experiment.stop_time = 1.0
+
+        fmu = Component()
+        fmu.name = "component"
+        fmu.component_type = "application/x-fmu-sharedlibrary"
+        fmu.source = "resources/example.fmu"
+        fmu.implementation = "CoSimulation"
+
+        fmu.connectors.append(Connector(None, "x", "output"))
+
+        ssd.system = System(None, "system")
+        ssd.system.elements.append(fmu)
+
+        ssd.system.connectors.append(Connector(None, "x", "output"))
+        ssd.add_connection(Connection(start_element="component", start_connector="x", end_connector="x"))
+
+    with SSD(write_file, mode="r") as ssd:
+        assert ssd.name == "Test SSD"
+        assert ssd.version == "1.0"
+
+        assert ssd.default_experiment.start_time == 0.0
+        assert ssd.default_experiment.stop_time == 1.0
+
+        assert len(ssd.system.elements) == 1
+        fmu = ssd.system.elements[0]
+
+        assert isinstance(fmu, Component)
+        assert fmu.name == "component"
+        assert fmu.component_type == "application/x-fmu-sharedlibrary"
+        assert fmu.source == "resources/example.fmu"
+        assert fmu.implementation == "CoSimulation"
+
+        assert len(fmu.connectors) == 1
+        fmu_conn = fmu.connectors[0]
+        assert fmu_conn.name == "x"
+        assert fmu_conn.kind == "output"
+
+        assert len(ssd.system.connectors) == 1
+        sys_conn = ssd.system.connectors[0]
+        assert sys_conn.name == "x"
+        assert sys_conn.kind == "output"
+
+        assert len(ssd.connections()) == 1
+        connection = ssd.connections()[0]
+
+        assert connection.start_element == "component"
+        assert connection.start_connector == "x"
+        assert connection.end_element is None
+        assert connection.end_connector == "x"

--- a/pytest/test_ssp.py
+++ b/pytest/test_ssp.py
@@ -1,13 +1,22 @@
+import tempfile
+from pathlib import Path
+import shutil
 
 import pytest
-from pathlib import Path
+
 from pyssp_standard.ssp import SSP
-import shutil
 
 
 @pytest.fixture
 def read_file():
     return Path("pytest/doc/embrace.ssp")
+
+
+@pytest.fixture
+def write_file():
+    with tempfile.NamedTemporaryFile(delete_on_close=False) as f:
+        f.close()
+        yield f.name
 
 
 def test_unpacking(read_file):
@@ -17,10 +26,10 @@ def test_unpacking(read_file):
 
 def test_add_resource(read_file):
     print()
-    test_ssp_file = Path('./embrace.ssp')
+    test_ssp_file = Path("./embrace.ssp")
     shutil.copy(read_file, test_ssp_file)
 
-    file_to_add = Path('pytest/doc/test.txt')
+    file_to_add = Path("pytest/doc/test.txt")
     with SSP(test_ssp_file) as ssp:
         file_to_remove = ssp.resources[0]
         print(file_to_remove)
@@ -34,3 +43,8 @@ def test_add_resource(read_file):
         assert file_to_remove not in [entry for entry in ssp.resources]
 
     test_ssp_file.unlink()
+
+
+def test_create_ssp(write_file):
+    with SSP(write_file, mode="w") as ssp:
+        assert isinstance(ssp, SSP)

--- a/pytest/test_utils.py
+++ b/pytest/test_utils.py
@@ -18,7 +18,7 @@ def test_zipfile():
         zf.add_file(file_to_add, "resources")
         zf.remove_file(file_to_remove)
 
-    with ZIPFile(source_path=target_file, readonly=True) as zf:
+    with ZIPFile(source_path=target_file, mode="r") as zf:
         files = zf.files_rel
 
         assert file_to_add.name in files


### PR DESCRIPTION
Implement support for creating new SSP archives. This is done by
* allowing creation of empty zip files
* extensive modifications to SSD support to enable creating new SSD files
* deprecating the ssd property, replacing it with a `system_structure` accessor for the default ssd, and a `variants` proxy for accessing the variant ssds.

I've created an SSP wrapping an FMU using this and successfully imported and simulated the SSP in Dymola.

Marked as draft, since the code needs to be cleaned up a bit, and tested further.