### PR TITLE
Add min, max, start attributes to TypeReal

### DIFF
--- a/pyssp_standard/common_content_ssc.py
+++ b/pyssp_standard/common_content_ssc.py
@@ -10,7 +10,6 @@ from pyssp_standard.standard import ModelicaStandard
 
 
 class Annotation(ModelicaStandard):  # TODO needs to read and not just create
-
     def __init__(self, type_declaration):
         """
         The SSP standard allows for the addition of annotations, when created they must contain at least one annotation.
@@ -19,7 +18,9 @@ class Annotation(ModelicaStandard):  # TODO needs to read and not just create
         :param type_declaration: normalized string
         """
         if type(type_declaration) is str:
-            self.root = ET.Element(QName(self.namespaces['ssc'], 'Annotation'), attrib={"type": type_declaration})
+            self.root = ET.Element(
+                QName(self.namespaces["ssc"], "Annotation"), attrib={"type": type_declaration}
+            )
         elif type(type_declaration) is ET._Element:
             self.root = type_declaration
 
@@ -34,10 +35,9 @@ class Annotation(ModelicaStandard):  # TODO needs to read and not just create
 
 
 class Annotations(ModelicaStandard):
-
     def __init__(self, namespace="ssc"):
         self.__count = 0
-        self.root = ET.Element(QName(self.namespaces[namespace], 'Annotations'))
+        self.root = ET.Element(QName(self.namespaces[namespace], "Annotations"))
 
     def add_annotation(self, annotation: Annotation):
         self.__count += 1
@@ -85,7 +85,7 @@ class TopLevelMetaData:
     def __repr__(self):
         base_txt = ""
         for field in fields(self):
-            reformatted_text = field.name.replace('_', ' ')
+            reformatted_text = field.name.replace("_", " ")
             reformatted_text = reformatted_text.capitalize()
             base_txt += f"{reformatted_text}: {getattr(self, field.name)}\n"
         return base_txt
@@ -116,9 +116,7 @@ class Item(ModelicaStandard):
 
     def to_xml(self):
         return ET.Element(
-                QName(self.namespaces["ssc"], "Item"),
-                name=self.name,
-                value=str(self.value)
+            QName(self.namespaces["ssc"], "Item"), name=self.name, value=str(self.value)
         )
 
 
@@ -164,7 +162,7 @@ class Enumerations(ModelicaStandard):
         self.enumerations.extend(Enumeration.from_xml(elem) for elem in element)
 
     def as_element(self):
-        elem = ET.Element(QName(self.namespaces[self.namespace], 'Enumerations'))
+        elem = ET.Element(QName(self.namespaces[self.namespace], "Enumerations"))
         for enum in self.enumerations:
             elem.append(enum.to_xml())
 
@@ -178,14 +176,16 @@ _prefix = f"{{{ModelicaStandard.namespaces['ssc']}}}"
 
 
 class TypeChoice(ABC, ModelicaStandard):
-    XPATH_SSP = ET.ETXPath("|".join(_prefix + type_ for type_ in
-            ["Real", "Integer", "Boolean", "String", "Enumeration"]))
+    XPATH_SSP = ET.ETXPath(
+        "|".join(
+            _prefix + type_ for type_ in ["Real", "Integer", "Boolean", "String", "Enumeration"]
+        )
+    )
 
     XPATH_FMI = "Real|Integer|Boolean|String|Enumeration"
 
     @abstractmethod
-    def to_xml(self, namespace="ssc"):
-        ...
+    def to_xml(self, namespace="ssc"): ...
 
     @classmethod
     def from_xml(cls, elem):
@@ -205,8 +205,11 @@ class TypeChoice(ABC, ModelicaStandard):
 
 
 class TypeReal(TypeChoice):
-    def __init__(self, unit):
+    def __init__(self, unit, min=None, max=None, start=None):
         self.unit = unit
+        self.min = min
+        self.max = max
+        self.start = start
 
     def to_xml(self, namespace="ssc"):
         if namespace:
@@ -218,11 +221,26 @@ class TypeReal(TypeChoice):
         if self.unit is not None:
             elem.set("unit", self.unit)
 
+        if namespace == "":  # fmi
+            if self.min is not None:
+                elem.set("min", str(self.min))
+
+            if self.max is not None:
+                elem.set("max", str(self.max))
+
+            if self.start is not None:
+                elem.set("start", str(self.start))
+
         return elem
 
     @classmethod
     def from_xml(cls, elem):
-        return cls(elem.get("unit"))
+        keys = ("min", "max", "start")
+
+        return cls(
+            unit=elem.get("unit"),
+            **{key: float(v) for key in keys if (v := elem.get(key)) is not None},
+        )
 
 
 class TypeInteger(TypeChoice):


### PR DESCRIPTION
These attributes are optional in FMI model description files, but not allowed in SSP. When reading, pass along these attributes to the init method if found in the document. When writing, only write these attributes if writing to an FMI (empty namespace).